### PR TITLE
Removed mitm / poisening based attacks (not allowed in the labs/exam)

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,16 +430,6 @@ Information Gathering & Vulnerability Scanning
 
         -   Linux: `smbclient -L //$ip`
 
--   LLMNR / NBT-NS Spoofing - Steal credentials off the network.
-
-    -   Spoof / poison LLMNR / NetBIOS requests:  
-        auxiliary/spoof/llmnr/llmnr\_response  
-        auxiliary/spoof/nbns/nbns\_response
-
-    -   Capture the hashes:  
-        auxiliary/server/capture/smb  
-        auxiliary/server/capture/http\_ntlm
-
 -   SMTP Enumeration - Mail Severs
 
     -   Verify SMTP port using Netcat  

--- a/README.md
+++ b/README.md
@@ -440,10 +440,6 @@ Information Gathering & Vulnerability Scanning
         auxiliary/server/capture/smb  
         auxiliary/server/capture/http\_ntlm
 
-    -   Using Responder to Steal Creds  
-        `git clone https://github.com/SpiderLabs/Responder.git  `
-        `python Responder.py -i local-ip -I eth0`
-
 -   SMTP Enumeration - Mail Severs
 
     -   Verify SMTP port using Netcat  


### PR DESCRIPTION
Removed mitm / poisening based attacks (not allowed in the labs/exam)

Restrictions under lab behavior mentions not to use any type of poisoning or mitm attacks in the lab. See: https://support.offensive-security.com/#!pwk-network-intro-guide.md (under lab behaviour)